### PR TITLE
Display paths of files containing duplicate steps

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -92,7 +92,7 @@ end
 function readstepdefinitions!(driver::Driver, path::String)
     stepdefinitionfiles = findfileswithextension(driver.os, path, ".jl")
     for f in stepdefinitionfiles
-        addmatcher!(driver.engine, FromMacroStepDefinitionMatcher(readfile(driver.os, f)))
+        addmatcher!(driver.engine, FromMacroStepDefinitionMatcher(readfile(driver.os, f), filename = f))
     end
 end
 


### PR DESCRIPTION
### Problem

File path(s) of step files, which contain duplicate steps, are not displayed in error message.

### How to reproduce

In a 'steps' file(s) duplicate a step used in an existing scenario.

```julia
# features/steps/ExperimentSteps.jl

@given("a machine filled with coffee beans") do context
    context[:machine] = Machine(coffee=5.0)
end

@given("a machine filled with coffee beans") do context
end
```

Run the tests

```julia-repl
(MPackage) pkg> test
     Testing MPackage
     ...
     Testing Running tests...

Feature: Making Coffee
  Scenario: Making a regular coffee
    Given a machine filled with coffee beans

        Multiple matches found:
          In <no filename>
          In <no filename>

     When a user makes a cup of coffee
     ...
                         | Success | Failure
  Feature: Making Coffee | 0       | 1


FAILURE

```
Expected to see the file path(s) of the steps files which contain the duplicate rules - instead: `<no filename>`.

### Solution

The problem looks to be in the `readstepdefinitions!` function in `src/engine.jl`. The constructor of `FromMacroStepDefinitionMatcher` takes an optional `filename` argument which has a default value of `<no filename>`. A `filename` argument is not provided.

With the 'fix' we now get the full paths of the offending step files.

```
     Multiple matches found:
        In /home/michael/projects/scratch/MyProject/MPackage/features/steps/ExperimentSteps.jl
        In /home/michael/projects/scratch/MyProject/MPackage/features/steps/ExperimentSteps.jl
```

### Observations

Despite the multiple definitions being in one file, in the above example, the path is printed twice. Perhaps the offending file name should be printed once? Although an argument against this is that the existing approach gives an indication of how many duplicates there are.

The absolute file paths are printed. Printing long path names can be ugly and take up screen real estate. Perhaps only the path from where the tests are run should be printed?

```
     Multiple matches found:
        In MPackage/features/steps/ExperimentSteps.jl
        In MPackage/features/steps/ExperimentSteps.jl
```

Although I can see a number of problems here:

- Would require adding a dependency such as [FilePaths.jl](https://github.com/rofinn/FilePaths.jl) to manipulate file paths.
- Might be problem establishing where the tests were run?

The biggest argument against the above is printing out the full path gives an unambiguous answer as to where the problem(s) lies.
