### PR TITLE
Display file name on error in step file

### DIFF
--- a/src/stepdefinitions.jl
+++ b/src/stepdefinitions.jl
@@ -197,7 +197,7 @@ struct FromMacroStepDefinitionMatcher <: StepDefinitionMatcher
         global currentfilename
         currentfilename = filename
         # Read all step definitions as Julia code.
-        include_string(Main, source)
+        include_string(Main, source, filename)
         # Save the step definitions found in the global variable `currentdefinitions` into a local
         # variable, so that we can clear the global state and read another file.
         mydefinitions = currentdefinitions


### PR DESCRIPTION
### Enhancement

File name not displayed when error caught in step file

### How to reproduce

In a 'steps' file(s), for a step used in an existing scenario, introduce an intentional error: 

```julia
# features/steps/ExperimentSteps.jl

@given("a machine filled with coffee beans") do context
    # Should be 'Machine(coffee=5.0)' not 'machine(coffee=5.0)'
    context[:machine] = machine(coffee=5.0)
end

```

Run the tests

```julia-repl
(MPackage) pkg> test
     Testing MPackage
     ...
     Testing Running tests...

Feature: Making Coffee
  Scenario: Making a regular coffee
    Given a machine filled with coffee beans

        Exception: UndefVarError(:machine)
          (::var"#3#6")(context::Behavior.StepDefinitionContext) at string:18

```

Instead of the name of the file, we get 'string:18' 

### Solution

The built-in `include_string` (`base/loading.jl`) can take an optional `filename` argument, the default value being 'string'. 

With the file name being passed:

```
        Exception: UndefVarError(:machine)
          (::var"#3#6")(context::Behavior.StepDefinitionContext) at ExperimentSteps.jl:18
          #2 at stepdefinitions.jl:140 [inlined]
```
