### PR TITLE
Break up if the first failure occures

### DIFF
--- a/src/executor.jl
+++ b/src/executor.jl
@@ -154,6 +154,11 @@ function executescenario(executor::Executor, background::Gherkin.Background, sce
     # Execute the Scenario
     results, _isfailedyet = executesteps(executor, context, scenario.steps, isfailedyet)
 
+    should_break_yet = GlobalExecEnv.envs[:break_after_error]()
+    if _isfailedyet && should_break_yet
+        throw("Break after error in Scenario $(scenario.description)")
+    end
+
     afterscenario(executor.executionenv, context, scenario)
 
     scenarioresult = ScenarioResult(results, scenario, background, backgroundresults)

--- a/src/executor.jl
+++ b/src/executor.jl
@@ -154,6 +154,7 @@ function executescenario(executor::Executor, background::Gherkin.Background, sce
     # Execute the Scenario
     results, _isfailedyet = executesteps(executor, context, scenario.steps, isfailedyet)
 
+    # break if the environment variable for break up was set and an error occures.
     should_break_yet = GlobalExecEnv.envs[:break_after_error]()
     if _isfailedyet && should_break_yet
         throw("Break after error in Scenario $(scenario.description)")

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -127,6 +127,8 @@ function runspec(
         NoExecutionEnvironment()
     end
 
+    # set the environment variable for make it possible to break up the test
+    # run after the first failure occurse
     GlobalExecEnv.envs[:break_after_error] = (() -> break_by_error)
 
 

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -117,6 +117,7 @@ function runspec(
     parseoptions::ParseOptions=ParseOptions(),
     presenter::RealTimePresenter=ColorConsolePresenter(),
     tags::String = "",
+    break_by_error::Bool = false,
 )
     os = OSAL()
 
@@ -125,6 +126,9 @@ function runspec(
     else
         NoExecutionEnvironment()
     end
+
+    GlobalExecEnv.envs[:break_after_error] = (() -> break_by_error)
+
 
     if parseoptions.use_experimental
         println("WARNING: Experimental parser used for feature files!")


### PR DESCRIPTION
Hi Erik
This pull request is more a prove of concept than a fully elaborate solution. The intend of this pull request is, that I faced during the work the need to abort the test run when the first error occurs. Otherwise I had to wait until all tests are ready. In the case of the BDD tests in TypeDB this can be several minutes. So I want shorten this process. As I said this is only a showcase what I was trying to achieve not a full fledged implementation.

Best Frank