### PR TITLE
gherkin: fix CRLF line ending support

### DIFF
--- a/src/GherkinExperimental.jl
+++ b/src/GherkinExperimental.jl
@@ -23,7 +23,7 @@ using Behavior.Gherkin: ScenarioOutline
 struct GherkinSource
     lines::Vector{String}
 
-    GherkinSource(source::String) = new(split(strip(source), "\n"))
+    GherkinSource(source::String) = new(split(strip(source), r"\r?\n"))
 end
 
 notempty(s) = !isempty(strip(s))


### PR DESCRIPTION
Updated GherkinSource to use regex pattern r"\r?\n" instead of "\n" to properly handle both Unix (LF) and Windows (CRLF) line endings.

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(so be aware)