### PR TITLE
presenter: fix output formatting on Windows

### DIFF
--- a/src/presenter.jl
+++ b/src/presenter.jl
@@ -100,7 +100,11 @@ end
 
 function present(presenter::ColorConsolePresenter, step::Gherkin.ScenarioStep, result::StepExecutionResult)
     color = stepcolor(presenter, result)
-    printstyled(presenter.io, "\r    $(stepformat(step))\n"; color=color)
+    # Clear the line by moving to the beginning and printing spaces, then move back
+    # This ensures proper behavior on both Unix and Windows systems
+    steptext = "    $(stepformat(step))"
+    print(presenter.io, "\r", " " ^ length(steptext), "\r")
+    printstyled(presenter.io, steptext, "\n"; color=color)
 
     resultmessage = stepresultmessage(result)
     if !isempty(resultmessage)


### PR DESCRIPTION
Fixed column misalignment issue on Windows by properly clearing the line before reprinting. The carriage return (\r) alone was causing columns to overwrite incorrectly on Windows systems.

The fix:
- Calculate step text length
- Move to beginning of line with \r
- Overwrite with spaces to clear
- Move back to beginning
- Print step text with correct color

This ensures consistent behavior across Unix and Windows platforms.

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)